### PR TITLE
fix rag store initialization bug and remove other gpt models

### DIFF
--- a/app/components/chat.tsx
+++ b/app/components/chat.tsx
@@ -535,12 +535,6 @@ export function ChatActions(props: {
             });
           }}
         />
-
-        <ChatAction
-          onClick={() => setShowModelSelector(true)}
-          text={currentModel}
-          icon={<RobotIcon />}
-        />
         <ChatAction
           onClick={props.showRagPromptModal}
           icon={<BrainIcon />}

--- a/app/components/home.tsx
+++ b/app/components/home.tsx
@@ -32,6 +32,7 @@ import { useAccessStore, useChatStore } from "../store";
 import { ProductionInfo } from "../utils/datatypes";
 import { 
   getKnowledgeGraphInfo, 
+  getLLMModels, 
   getMaskInfo, 
   getVectorStoreInfo 
 } from "../utils/prodinfo";
@@ -225,8 +226,10 @@ export function Home() {
       useChatStore.getState().initializeChat(mask);
       const ragInfo = getVectorStoreInfo(theProdInfo);
       const kgInfo = getKnowledgeGraphInfo(theProdInfo);
+      const models = getLLMModels(theProdInfo);
       useRAGStore.getState().initializeRAG(ragInfo);
       useKGStore.getState().initializeKG(kgInfo);
+      useAppConfig.getState().initializeConfig(models);
     });
   }, []);
 

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -117,59 +117,7 @@ export const KnowledgeCutOffDate: Record<string, string> = {
 
 export const DEFAULT_MODELS = [
   {
-    name: "gpt-4",
-    available: true,
-  },
-  {
-    name: "gpt-4-0314",
-    available: true,
-  },
-  {
-    name: "gpt-4-0613",
-    available: true,
-  },
-  {
-    name: "gpt-4-32k",
-    available: true,
-  },
-  {
-    name: "gpt-4-32k-0314",
-    available: true,
-  },
-  {
-    name: "gpt-4-32k-0613",
-    available: true,
-  },
-  {
-    name: "gpt-4-1106-preview",
-    available: true,
-  },
-  {
-    name: "gpt-4-vision-preview",
-    available: true,
-  },
-  {
-    name: "gpt-3.5-turbo",
-    available: true,
-  },
-  {
-    name: "gpt-3.5-turbo-0301",
-    available: true,
-  },
-  {
-    name: "gpt-3.5-turbo-0613",
-    available: true,
-  },
-  {
-    name: "gpt-3.5-turbo-1106",
-    available: true,
-  },
-  {
-    name: "gpt-3.5-turbo-16k",
-    available: true,
-  },
-  {
-    name: "gpt-3.5-turbo-16k-0613",
+    name: "gpt-4o",
     available: true,
   },
 ] as const;

--- a/app/masks/en.ts
+++ b/app/masks/en.ts
@@ -1,5 +1,7 @@
 import { BuiltinMask } from "./typing";
 
+const DEFAULT_MODEL = "gpt-4o";
+
 export const EN_MASKS: BuiltinMask[] = [
   // {
   //   avatar: "1f47e",
@@ -161,7 +163,7 @@ export const EN_MASKS: BuiltinMask[] = [
       },
     ],
     modelConfig: {
-      model: "gpt-3.5-turbo",
+      model: DEFAULT_MODEL,
       temperature: 0,
       max_tokens: 2000,
       presence_penalty: 0,
@@ -179,7 +181,7 @@ export const EN_MASKS: BuiltinMask[] = [
     name: "Plain conversation",
     context: [],
     modelConfig: {
-      model: "gpt-3.5-turbo",
+      model: DEFAULT_MODEL,
       temperature: 0,
       max_tokens: 2000,
       presence_penalty: 0,
@@ -218,7 +220,7 @@ export const EN_MASKS: BuiltinMask[] = [
       },
     ],
     modelConfig: {
-      model: "gpt-3.5-turbo",
+      model: DEFAULT_MODEL,
       temperature: 0,
       max_tokens: 2000,
       presence_penalty: 0,
@@ -257,7 +259,7 @@ export const EN_MASKS: BuiltinMask[] = [
       },
     ],
     modelConfig: {
-      model: "gpt-3.5-turbo",
+      model: DEFAULT_MODEL,
       temperature: 0,
       max_tokens: 2000,
       presence_penalty: 0,
@@ -296,7 +298,7 @@ export const EN_MASKS: BuiltinMask[] = [
       },
     ],
     modelConfig: {
-      model: "gpt-3.5-turbo",
+      model: DEFAULT_MODEL,
       temperature: 0,
       max_tokens: 2000,
       presence_penalty: 0,
@@ -328,7 +330,7 @@ export const EN_MASKS: BuiltinMask[] = [
       },
     ],
     modelConfig: {
-      model: "gpt-3.5-turbo",
+      model: DEFAULT_MODEL,
       temperature: 0,
       max_tokens: 2000,
       presence_penalty: 0,
@@ -367,7 +369,7 @@ export const EN_MASKS: BuiltinMask[] = [
       },
     ],
     modelConfig: {
-      model: "gpt-3.5-turbo",
+      model: DEFAULT_MODEL,
       temperature: 0,
       max_tokens: 2000,
       presence_penalty: 0,
@@ -398,7 +400,7 @@ export const EN_MASKS: BuiltinMask[] = [
       },
     ],
     modelConfig: {
-      model: "gpt-3.5-turbo",
+      model: DEFAULT_MODEL,
       temperature: 0,
       max_tokens: 2000,
       presence_penalty: 0,

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -105,6 +105,14 @@ export const useAppConfig = createPersistStore(
     reset() {
       set(() => ({ ...DEFAULT_CONFIG }));
     },
+    initializeConfig(models?: LLMModel[]) {
+      if (!models) {
+        return;
+      }
+      set(() => ({
+        models
+      }))
+    },
 
     mergeModels(newModels: LLMModel[]) {
       if (!newModels || newModels.length === 0) {

--- a/app/store/rag.ts
+++ b/app/store/rag.ts
@@ -83,7 +83,7 @@ export const useRAGStore = createPersistStore(
         }
         const configs = _get().configs;
         if (
-          configs.length > 1 || is_rag_config_default_config(configs[0])
+          configs.length > 1 || !is_rag_config_default_config(configs[0])
         ) {
           return;
         }

--- a/app/utils/datatypes.ts
+++ b/app/utils/datatypes.ts
@@ -1,3 +1,4 @@
+import { LLMModel } from "../client/api";
 import { Mask } from "../store/mask";
 
 export interface DbConnectionArgs {
@@ -46,4 +47,5 @@ export interface ProductionInfo {
   VectorStore?: DbConfiguration;
   OncoKBAPI?: APIAgentInfo;
   Text?: TextConfiguration;
+  LLMModels?: Array<LLMModel>;
 }

--- a/app/utils/prodinfo.ts
+++ b/app/utils/prodinfo.ts
@@ -7,6 +7,7 @@ import {
   ProductionInfo 
 } from "./datatypes";
 import Locale  from "../locales";
+import { LLMModel } from "../client/api";
 
 export function getOncoKBInfo(prodInfo?: ProductionInfo): APIAgentInfo {
   return (prodInfo?.OncoKBAPI ?? {enabled: true})
@@ -18,6 +19,9 @@ export function getKnowledgeGraphInfo(prodInfo?: ProductionInfo): DbConfiguratio
 
 export function getVectorStoreInfo(prodInfo?: ProductionInfo): DbConfiguration {
   return (prodInfo?.VectorStore ?? {servers: [], enabled: true});
+}
+export function getLLMModels(prodInfo?: ProductionInfo): Array<LLMModel> | undefined {
+  return prodInfo?.LLMModels;
 }
 
 export function selectServerInfoFromDbConnectionArgs(


### PR DESCRIPTION
### Abstract
This submission fixed the bug in initializing rag store, and remove gpt models selector in Chatbox.  This submission also introduced the support of gpt models in biochatter-next.yaml:
```
LLMModels:
  - name: gpt-4o-mini
    available: true
```
This will be displayed in settings
![image](https://github.com/user-attachments/assets/00cbe80a-b9b5-478e-b1bc-989a011988ba)
